### PR TITLE
Update tests to support fatal errors

### DIFF
--- a/testsuite/integration/README.md
+++ b/testsuite/integration/README.md
@@ -15,7 +15,7 @@ make setup
 ```
 
 Build a version of the integration test container using only the `testbase`
-stage, so it has the tests but doesn't automatically run the tests:
+stage, so it has the test environment but doesn't automatically run the tests:
 
 ```console
 docker build -t local/integration-test:test --target testbase --no-cache .

--- a/testsuite/integration/src/features/test_environment.feature
+++ b/testsuite/integration/src/features/test_environment.feature
@@ -1,5 +1,5 @@
 #
-# Copyright 2022 Hewlett Packard Enterprise Development LP
+# Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 # Other additional copyright holders may be indicated within.
 #
 # The entirety of this work is licensed under the Apache License,
@@ -16,6 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+@environment
 Feature: Integration test environment
     Verify the integration test environment has been setup correctly
 

--- a/testsuite/integration/src/pytest.ini
+++ b/testsuite/integration/src/pytest.ini
@@ -1,5 +1,5 @@
 #
-# Copyright 2022 Hewlett Packard Enterprise Development LP
+# Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 # Other additional copyright holders may be indicated within.
 #
 # The entirety of this work is licensed under the Apache License,
@@ -19,3 +19,7 @@
 
 [pytest]
 bdd_features_base_dir = features
+markers =
+  environment
+  dws_states
+

--- a/testsuite/integration/src/tests/conftest.py
+++ b/testsuite/integration/src/tests/conftest.py
@@ -18,19 +18,18 @@
 #
 
 import os
-import pytest
 import secrets
 import warnings
+import pytest
 
-from .slurmctld import Slurmctld
 from kubernetes import client, config
 from pytest_bdd import (
     given,
-    scenarios,
     parsers,
     then,
     when,
 )
+from .slurmctld import Slurmctld
 
 @pytest.fixture
 def k8s():
@@ -54,7 +53,7 @@ def pytest_bdd_apply_tag(tag, function):
 def _(script):
     """a job script: <script>"""
     path = "/jobs/inttest-" + secrets.token_hex(5) + "-job.sh"
-    with open(path, "w") as file:
+    with open(path, "w", encoding="utf-8") as file:
         file.write(script)
 
     yield path
@@ -87,4 +86,3 @@ def _(slurmctld, jobId, expectedJobState):
         return
 
     assert jobState == expectedJobState, "Unexpected Job State: " + jobState + "\n" + out
-

--- a/testsuite/integration/src/tests/dws_bb_plugin/workflow.py
+++ b/testsuite/integration/src/tests/dws_bb_plugin/workflow.py
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-from kubernetes import client, config
+from kubernetes import config
 from tenacity import *
 
 class WorkflowWaitError(Exception):
@@ -38,7 +38,7 @@ class Workflow:
 
     @property
     def data(self):
-        if self._data == None:
+        if self._data is None:
             self._data = self._get_data()
         return self._data
 
@@ -67,7 +67,7 @@ class Workflow:
             raise WorkflowWaitError(self.name, description)
         print("ready")
         self._data = wf.data
-    
+
     def save_driver_statuses(self):
         patchData = {
             "status": {
@@ -77,7 +77,7 @@ class Workflow:
         self.k8s.CustomObjectsApi().patch_namespaced_custom_object(
             "dws.cray.hpe.com", self._api_version, "slurm", "workflows", self.name, patchData
         )
-        
+
     def delete(self):
         self.k8s.CustomObjectsApi().delete_namespaced_custom_object(
             "dws.cray.hpe.com", self._api_version, "slurm", "workflows", self.name

--- a/testsuite/integration/src/tests/slurmctld.py
+++ b/testsuite/integration/src/tests/slurmctld.py
@@ -49,11 +49,6 @@ class Slurmctld:
         )
         return rc,str(out, 'utf-8')
     
-    #@retry(
-    #    wait=wait_fixed(2),
-    #    stop=stop_after_attempt(30),
-    #    reraise=True
-    #)
     def submit_job(self, scriptPath):
         # The --wait option could be used here. However, other tests need to
         # asynchronously track the job status

--- a/testsuite/integration/src/tests/slurmctld.py
+++ b/testsuite/integration/src/tests/slurmctld.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2022 Hewlett Packard Enterprise Development LP
+# Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 # Other additional copyright holders may be indicated within.
 #
 # The entirety of this work is licensed under the Apache License,
@@ -17,15 +17,15 @@
 # limitations under the License.
 #
 
-import docker
 import os
-import warnings
+import time
+import docker
 from tenacity import *
 
 # Submitting jobs can fail, occasionally, when the DWS webhook rejects the
 # mutating webhook connection. This has only been observed using the
 # directive rules included with  the dws-test-driver in a local kind
-# environment. 
+# environment.
 class JobSubmissionError(Exception):
     pass
 
@@ -49,11 +49,11 @@ class Slurmctld:
         )
         return rc,str(out, 'utf-8')
     
-    @retry(
-        wait=wait_fixed(2),
-        stop=stop_after_attempt(30),
-        reraise=True
-    )
+    #@retry(
+    #    wait=wait_fixed(2),
+    #    stop=stop_after_attempt(30),
+    #    reraise=True
+    #)
     def submit_job(self, scriptPath):
         # The --wait option could be used here. However, other tests need to
         # asynchronously track the job status
@@ -71,11 +71,6 @@ class Slurmctld:
         if rc != 0:
             raise JobCancelError(out)
 
-    @retry(
-        wait=wait_fixed(2),
-        stop=stop_after_attempt(30),
-        retry_error_callback=lambda retry_state: None
-    )
     def remove_job_output(self, jobId, outputFilePath, errorFilePath):
         """
         The creation of the job's output file will sometimes lag behind the
@@ -83,9 +78,24 @@ class Slurmctld:
         don't raise a test error.
         """
         if os.path.exists(errorFilePath):
-            with open(errorFilePath, "r") as errorFile: print(errorFile.read())
+            with open(errorFilePath, "r", encoding="utf-8") as errorFile:
+                print(errorFile.read())
             os.remove(errorFilePath)
-        os.remove(outputFilePath)
+        if os.path.exists(outputFilePath):
+            os.remove(outputFilePath)
+
+    @retry(
+        wait=wait_fixed(2),
+        stop=stop_after_attempt(30)
+    )
+    def wait_until_workflow_is_gone(self, jobId):
+        _, out = self.exec_run("scontrol show bbstat workflow " + str(jobId))
+        # We'd prefer to check that rc==0, but the scontrol command does not
+        # exit non-zero when slurm_bb_get_status() in burst_buffer.lua returns
+        # slurm.ERROR.
+        if 'Error running slurm_bb_get_status' not in out:
+            print(f"Workflow {jobId} still exists: " + out)
+            raise JobNotCompleteError()
 
     @retry(
         wait=wait_fixed(2),
@@ -93,14 +103,16 @@ class Slurmctld:
         retry=retry_if_result(lambda state: state[0] not in ["COMPLETED", "FAILED", "CANCELLED"]),
         retry_error_callback=lambda retry_state: retry_state.outcome.result()
     )
-    def get_final_job_state(self, jobId):
-        # When the job is finished, the workflow should not exist
-        rc = self.exec_run("scontrol show bbstat workflow " + str(jobId))
-        if rc == 0:
-            raise JobNotCompleteError()
+    def get_final_job_state(self, jobId, must_be_gone=True):
+        # When the job is finished, the workflow should not exist.
+        if must_be_gone:
+            self.wait_until_workflow_is_gone(jobId)
+        else:
+            time.sleep(5) # wait for workflow info to be transferred to the job
 
-        rc, out =self.exec_run("scontrol show job " + str(jobId))
+        rc, out = self.exec_run("scontrol show job " + str(jobId))
         assert rc==0, "Could not get job state from Slurm:\n" + out
+
         job_prop_lines = out.split("\n")
         assert len(job_prop_lines) >= 4, "Could not find job: " + jobId + "\n" + out
         for job_prop_line in job_prop_lines:
@@ -115,7 +127,11 @@ class Slurmctld:
 
     def get_workflow_status(self, jobId):
         rc, out = self.exec_run("scontrol show bbstat workflow " + str(jobId))
-        assert rc ==0, "Could not get job status from Slurm:\n" + out
+        assert rc == 0, "Could not get job status from Slurm:\n" + out
+        # This next check is because the scontrol command does not exit non-zero
+        # when slurm_bb_get_status() in burst_buffer.lua returns slurm.ERROR.
+        assert 'Error running slurm_bb_get_status' not in out, f"Could not find workflow {jobId}:\n" + out
+
         status = {}
         properties = out.split()
         for prop in properties:


### PR DESCRIPTION
DWS v0.0.11 has the concept of fatal errors.  This updates the tests to use fatal errors, and to show how drivers should handle them.

This also addresses a number of lint errors, but does not attempt to remove all of them.
