### PR TITLE
Smooth some bumps in the KIND env

### DIFF
--- a/testsuite/integration/Makefile
+++ b/testsuite/integration/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2022 Hewlett Packard Enterprise Development LP
+# Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 # Other additional copyright holders may be indicated within.
 #
 # The entirety of this work is licensed under the Apache License,
@@ -41,8 +41,8 @@ setup-dws:
 		cd ../submodules/dws ; \
 		docker buildx build -t local/dws-operator:test --load . ; \
 		IMAGE_TAG_BASE=local/dws-operator VERSION=test KIND_CLUSTER=dws make kind-push deploy ; \
-		kubectl wait deployment --timeout=60s -n dws-operator-system dws-operator-controller-manager --for condition=Available=True ; \
-		kubectl wait deployment --timeout=60s -n dws-operator-system dws-operator-webhook --for condition=Available=True ; \
+		kubectl wait deployment --timeout=120s -n dws-operator-system dws-operator-controller-manager --for condition=Available=True ; \
+		kubectl wait deployment --timeout=120s -n dws-operator-system dws-operator-webhook --for condition=Available=True ; \
 	}
 
 .PHONY: setup-dws-test-driver

--- a/testsuite/integration/kind/kind.sh
+++ b/testsuite/integration/kind/kind.sh
@@ -50,8 +50,18 @@ install_dependencies () {
   # Create the slurm namespace. This will be the default location of dws-slurm-bb-plugin workflows
   kubectl create namespace slurm
 
+  # Pull cert-manager into the local cache and push into KIND.  Sometimes
+  # the KIND env cannot pull it from upstream.
+  CERTVER=v1.11.1
+  for part in controller webhook cainjector
+  do
+      image=quay.io/jetstack/cert-manager-$part:$CERTVER
+      docker pull $image
+      kind load docker-image --name=dws $image
+  done
+
   # Install the cert-manager for the DWS webhook.
-  kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.11.1/cert-manager.yaml
+  kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/$CERTVER/cert-manager.yaml
 
   kubectl wait deployment --timeout=60s -n cert-manager cert-manager --for condition=Available=True
   kubectl wait deployment --timeout=60s -n cert-manager cert-manager-cainjector --for condition=Available=True


### PR DESCRIPTION
Allow a longer wait for the DWS webhook to start.

In a KIND env, help out when pulling cert-manager images.  When running in a local KIND env, within the HPE firewall, sometimes my KIND env cannot pull the cert-manager images.  So I first pull them into my local docker cache, and then push them into KIND from there.  This gives me a smoother load, and avoids a lot of time spent in ImagePullBackoff.