### PR TITLE
Adjust slurm_bb_get_status() 2-arg API vs 4-arg API

### DIFF
--- a/src/burst_buffer/burst_buffer.lua
+++ b/src/burst_buffer/burst_buffer.lua
@@ -844,10 +844,20 @@ function slurm_bb_get_status(...)
 	local args = {...}
 	args.n = select("#", ...)
 
+	local found_jid = false
+	local jid = 0
 	if args.n == 2 and args[1] == "workflow" then
+		-- Slurm 22.05
+		jid = args[2]
+		found_jid = true
+	elseif args.n == 4 and args[3] == "workflow" then
+		-- Slurm 23.02
+		jid = args[4]
+		found_jid = true
+	end
+	if found_jid == true then
 		local done = false
 		local status = {}
-		local jid = args[2]
 		if string.find(jid, "^%d+$") == nil then
 			msg = "A job ID must contain only digits."
 		else


### PR DESCRIPTION
Adjust slurm_bb_get_status() to work with both the older 2-arg API and the newer 4-arg API that comes in with slurm 23.02.4.1.