### PR TITLE
Handle DWS fatal errors

### DIFF
--- a/src/burst_buffer/burst_buffer.conf
+++ b/src/burst_buffer/burst_buffer.conf
@@ -3,3 +3,9 @@
 # See https://slurm.schedmd.com/burst_buffer.conf.html
 Directive=DW
 
+# If set, then teardown a burst buffer after file staging error. Otherwise
+# preserve the burst buffer for analysis and manual teardown.
+# See https://slurm.schedmd.com/burst_buffer.conf.html
+# and https://slurm.schedmd.com/burst_buffer.html#states
+Flags=TeardownFailure
+

--- a/src/burst_buffer/burst_buffer.lua
+++ b/src/burst_buffer/burst_buffer.lua
@@ -280,9 +280,16 @@ end
 
 -- DWS:get_driver_errors will collect driver errors from the Workflow resource
 -- with respect to the given state.
-function DWS:get_driver_errors(state)
-	local error_list = {}
-	local jsonpath = [[{range .status.drivers[?(@.watchState=="]].. state ..[[")]}==={"\n"}{@.status}{"\n"}{@.driverID}{"\n"}{@.error}{"\n"}{end}]]
+-- If all_errors=true then collect all errors from all states in all drivers.
+-- On success this returns true and a string with all of the errors.
+-- On failure this returns false, an empty string for the errors, and a string
+-- explaining why it couldn't collect the errors.
+function DWS:get_driver_errors(state, all_errors)
+	local driver_index = [[?(@.watchState=="]].. state ..[[")]]
+	if all_errors == true then
+		driver_index = "*"
+	end
+	local jsonpath = [[{range .status.drivers[]] .. driver_index .. [[]}==={"\n"}{@.status}{"\n"}{@.driverID}{"\n"}{@.error}{"\n"}{end}]]
 	local ret, output = self:get_jsonpath(jsonpath)
 	if ret == false then
 		return ret, "", "could not get driver errors: " .. output
@@ -440,6 +447,18 @@ function DWS:kubectl(cmd)
 	end
 	local kcmd = homedir_msg .. " kubectl " .. self:token() .. " " .. cmd
 	return self:io_popen(kcmd)
+end
+
+-- DWS:scancel will run the Slurm scancel command and collect its output.
+-- On success this returns true and the output of the command.
+-- On failure this returns false and the output of the command.
+function DWS:scancel(jobId, hurry)
+	local hurry_opt = ""
+	if hurry == true then
+		hurry_opt = "--hurry "
+	end
+	local scmd = "scancel " .. hurry_opt .. jobId
+	return self:io_popen(scmd)
 end
 
 -- DWS:io_popen will run the given command and collect its output.
@@ -627,24 +646,51 @@ function slurm_bb_job_teardown(job_id, job_script, hurry)
 		hurry_flag = true
 	end
 	local workflow = DWS(make_workflow_name(job_id))
-	local done, err = workflow:set_workflow_state_and_wait("Teardown", hurry_flag)
+
+	local ret = slurm.SUCCESS
+	-- Does the workflow have a fatal error in it?
+	-- If so, we'll call scancel as well.
+	local done, state_errors, err = workflow:get_driver_errors("", true)
 	if done == false then
 		if string.find(err, [["]] .. workflow.name .. [[" not found]]) then
 			-- It's already gone, and that's what we wanted anyway.
 			return slurm.SUCCESS
 		else
-			slurm.log_error("%s: slurm_bb_job_teardown(), workflow=%s: %s", lua_script_name, workflow.name, err)
-			return slurm.ERROR, err
+			slurm.log_error("%s: slurm_bb_job_teardown(), workflow=%s: unable to check driver errors: %s", lua_script_name, workflow.name, err)
+			ret = slurm.ERROR
+			-- fall-through, let the Workflow delete happen.
 		end
+	end
+
+	done, err = workflow:set_workflow_state_and_wait("Teardown", hurry_flag)
+	if done == false then
+		slurm.log_error("%s: slurm_bb_job_teardown(), workflow=%s: %s", lua_script_name, workflow.name, err)
+		ret = slurm.ERROR
+		-- fall-through, let the Workflow delete happen.
 	end
 
 	done, err = workflow:delete()
 	if done == false then
 		slurm.log_error("%s: slurm_bb_job_teardown(), workflow=%s, delete: %s", lua_script_name, workflow.name, err)
-		return slurm.ERROR, err
+		ret = slurm.ERROR
+		-- fall-through, let any necessary scancel happen.
 	end
 
-	return slurm.SUCCESS
+	if state_errors ~= "" then
+		-- Now do the scancel.  This will terminate this Lua script and will
+		-- trigger slurm to call our teardown again, but that'll be a no-op
+		-- when it comes back here.
+		slurm.log_info("%s: slurm_bb_job_teardown(), workflow=%s: executing scancel --hurry %s, found driver errors: %s", lua_script_name, workflow.name, job_id, state_errors)
+		_, err = workflow:scancel(job_id, true)
+		if err == "" then
+			err = "(no output)"
+		end
+	end
+
+	if ret == slurm.SUCCESS then
+		err = nil
+	end
+	return ret, err
 end
 
 --[[

--- a/testsuite/integration/src/features/test_dws_states.feature
+++ b/testsuite/integration/src/features/test_dws_states.feature
@@ -67,8 +67,8 @@ Feature: Data Workflow Services State Progression
         Then the job's system comment eventually contains the following:
             TEST FATAL ERROR
         And the Workflow and job progress to the Teardown state
-        And the job has eventually been CANCELLED
         And the Workflow has eventually been deleted
+        And the job has eventually been CANCELLED
         
         Examples:
             # *** HEADER ***
@@ -99,8 +99,8 @@ Feature: Data Workflow Services State Progression
         Then the job's system comment eventually contains the following:
             TEST FATAL ERROR
         And the Workflow and job progress to the Teardown state
-        And the job has eventually been COMPLETED
         And the Workflow has eventually been deleted
+        And the job has eventually been COMPLETED
         
         Examples:
             # *** HEADER ***
@@ -120,5 +120,5 @@ Feature: Data Workflow Services State Progression
         When the job is run
         And some Workflow has been created for the job
         And the Workflow reports fatal errors at the Teardown state
-        Then the job has eventually been COMPLETED
-        And the Workflow has eventually been deleted
+        Then the Workflow has eventually been deleted
+        And the job has eventually been COMPLETED

--- a/testsuite/integration/src/features/test_dws_states.feature
+++ b/testsuite/integration/src/features/test_dws_states.feature
@@ -22,6 +22,7 @@ Feature: Data Workflow Services State Progression
     Verify that the DWS-Slurm Burst Buffer Plugin progresses through Data
     Workflow Services states
 
+    @happy_one
     Scenario: The DWS-BB Plugin progresses through DWS states
         Given a job script:
             #!/bin/bash
@@ -44,13 +45,15 @@ Feature: Data Workflow Services State Progression
         And the Workflow and job progress to the PostRun state
         And the Workflow and job progress to the DataOut state
         And the Workflow and job progress to the Teardown state
-        And the job state is COMPLETED
+        And the job has eventually been COMPLETED
 
     # DWS does not allow spaces in key/value pairs in directives. To skirt around this
     # constraint, the dws-test-driver replaces underscores ("_") in the message value with
     # spaces. This ensures that the dws-slurm-plugin can handle whitespace in error messages
     # It also makes it easier to check that the error is included in scontrol output.
-    Scenario Outline: The DWS-BB Plugin can handle fatal driver errors before being canceled
+    # This scenario assumes that "Flags=TeardownFailure" is set in burst_buffer.conf.
+    @fatal_one
+    Scenario Outline: Report fatal errors from Proposal, Setup, DataIn, PreRun
         Given a job script:
             #!/bin/bash
             
@@ -59,12 +62,13 @@ Feature: Data Workflow Services State Progression
             /bin/hostname
 
         When the job is run
-        Then a Workflow has been created for the job
-        And the Workflow and job report fatal errors at the <workflowState> state
-        And the job is canceled
-        And the Workflow and job progress to the Teardown state
-        And the job's final system comment contains the following:
+        And some Workflow has been created for the job
+        And the Workflow reports fatal errors at the <workflowState> state
+        Then the job's system comment eventually contains the following:
             TEST FATAL ERROR
+        And the Workflow and job progress to the Teardown state
+        And the job has eventually been CANCELLED
+        And the Workflow has eventually been deleted
         
         Examples:
             # *** HEADER ***
@@ -73,14 +77,15 @@ Feature: Data Workflow Services State Progression
             | Proposal      |
             | Setup         |
             | DataIn        |
-            | PostRun       | 
-            | DataOut       | 
+            | PreRun        |
 
-    # With the exception of PreRun, states will need to be canceled with the
-    # "--hurry" flag to transition to the Teardown state. If 
-    # "Flags=TeardownFailure" is set in burst_buffer.conf, then all states will
-    # transition to Teardown without needing to be canceled
-    Scenario Outline: The DWS-BB Plugin can handle fatal driver errors for PreRun
+    # DWS does not allow spaces in key/value pairs in directives. To skirt around this
+    # constraint, the dws-test-driver replaces underscores ("_") in the message value with
+    # spaces. This ensures that the dws-slurm-plugin can handle whitespace in error messages
+    # It also makes it easier to check that the error is included in scontrol output.
+    # This scenario assumes that "Flags=TeardownFailure" is set in burst_buffer.conf.
+    @fatal_two
+    Scenario Outline: Report fatal errors from PostRun and DataOut
         Given a job script:
             #!/bin/bash
             
@@ -89,22 +94,23 @@ Feature: Data Workflow Services State Progression
             /bin/hostname
 
         When the job is run
-        Then a Workflow has been created for the job
-        And the Workflow reports a fatal error in the <workflowState> state
-        And the Workflow and job progress to the Teardown state
-        # Slurm moved it from PreRun/Error to Teardown without canceling
-        # the job.  So the driver (this test) must cancel it.
-        And the job is canceled
-        And the job's final system comment contains the following:
+        And some Workflow has been created for the job
+        And the Workflow reports fatal errors at the <workflowState> state
+        Then the job's system comment eventually contains the following:
             TEST FATAL ERROR
+        And the Workflow and job progress to the Teardown state
+        And the job has eventually been COMPLETED
+        And the Workflow has eventually been deleted
         
         Examples:
             # *** HEADER ***
             | workflowState |
             # *** VALUES ***
-            | PreRun        |
+            | PostRun       | 
+            | DataOut       |
 
-    Scenario: The DWS-BB Plugin can handle fatal driver errors during Teardown
+    @fatal_three
+    Scenario: Report fatal errors from Teardown
         Given a job script:
             #!/bin/bash
             
@@ -112,12 +118,7 @@ Feature: Data Workflow Services State Progression
             /bin/hostname
 
         When the job is run
-        Then a Workflow has been created for the job
-        And the Workflow reports a fatal error in the Teardown state
-        And the job's intermediate system comment contains the following:
-            TEST FATAL ERROR
-        # Eventually the driver (this test) must work through the Teardown
-        # issues and complete that step.  Slurm has already marked the job
-        # as completed and is now looping over slurm_bb_job_teardown() in
-        # burst_buffer.lua.
-        And the Workflow error is cleared from the Teardown state
+        And some Workflow has been created for the job
+        And the Workflow reports fatal errors at the Teardown state
+        Then the job has eventually been COMPLETED
+        And the Workflow has eventually been deleted

--- a/testsuite/integration/src/features/test_environment.feature
+++ b/testsuite/integration/src/features/test_environment.feature
@@ -36,7 +36,7 @@ Feature: Integration test environment
             srun -l /bin/hostname
             srun -l /bin/pwd
         When the job is run
-        Then the job state is COMPLETED
+        Then the job has eventually been COMPLETED
 
     Scenario: Kubernetes and slurm are connected
         Given the kubernetes cluster kube-system UID

--- a/testsuite/integration/src/pytest.ini
+++ b/testsuite/integration/src/pytest.ini
@@ -22,4 +22,7 @@ bdd_features_base_dir = features
 markers =
   environment
   dws_states
-
+  happy_one
+  fatal_one
+  fatal_two
+  fatal_three

--- a/testsuite/integration/src/tests/conftest.py
+++ b/testsuite/integration/src/tests/conftest.py
@@ -72,17 +72,7 @@ def _(slurmctld, script_path):
     # remove the slurm output from the jobs folder
     slurmctld.remove_job_output(jobId, outputFilePath, errorFilePath)
 
-@then(parsers.parse('the job state is {expectedJobState}'))
-def _(slurmctld, jobId, expectedJobState):
-    """the job state is <expectedJobState>"""
-    jobState, out = slurmctld.get_final_job_state(jobId)
-
-    if expectedJobState == "COMPLETED" and jobState == "FAILED":
-        warnings.warn(ResourceWarning((f"Job {jobId} failed unexpectedly.\n") + \
-            "This may happen if Slurm doesn't have enough resources to schedule the job.\n" + \
-            "This is not considered a test failure, in this context, since DWS isn't\n" + \
-            "dependent on the job's failure or success."
-        ))
-        return
-
-    assert jobState == expectedJobState, "Unexpected Job State: " + jobState + "\n" + out
+@then(parsers.parse('the job has eventually been {job_state:l}'))
+def _(slurmctld, jobId, job_state):
+    """the job has eventually been <job_state>"""
+    slurmctld.wait_until_job_has_been_x(jobId, job_state)

--- a/testsuite/unit/src/burst_buffer/dws-test.lua
+++ b/testsuite/unit/src/burst_buffer/dws-test.lua
@@ -855,11 +855,13 @@ describe("Slurm API", function()
 	end
 
 	local call_bb_teardown = function(hurry)
+		dwsmq_enqueue(true, "") -- get_driver_errors
+		dwsmq_enqueue(true, "") -- kubectl_cache_home
 		local delete_result = 'workflow.dataworkflowservices.github.io "' .. workflow_name .. '" deleted\n'
 		local popen_count = mock_popen_calls("Teardown", "Completed")
 		dwsmq_enqueue(true, "") -- kubectl_cache_home
 		dwsmq_enqueue(true, delete_result)
-		popen_count = popen_count + 2
+		popen_count = popen_count + 4
 
 		io.popen:clear()
 		local ret, err = slurm_bb_job_teardown(jobID, job_script_name, hurry)


### PR DESCRIPTION
Set Flags=TeardownFailure in burst_buffer.conf.  This tells Slurm to go to Teardown if there are errors during stage_in or stage_out.

In the burst_buffer.lua plugin, adjust slurm_bb_job_teardown() to check the workflow for any fatal errors recorded in the drivers array.  If any are found, then we know we were called in a fatal error situation and we not only delete the workflow, per usual, but we also call the Slurm `scancel` command to cancel the Slurm job.