### PR TITLE
Remove the fatal-eror-during-teardown test

### DIFF
--- a/testsuite/integration/src/features/test_dws_states.feature
+++ b/testsuite/integration/src/features/test_dws_states.feature
@@ -108,17 +108,3 @@ Feature: Data Workflow Services State Progression
             # *** VALUES ***
             | PostRun       | 
             | DataOut       |
-
-    @fatal_three
-    Scenario: Report fatal errors from Teardown
-        Given a job script:
-            #!/bin/bash
-            
-            #DW Teardown action=error message=TEST_FATAL_ERROR severity=Fatal
-            /bin/hostname
-
-        When the job is run
-        And some Workflow has been created for the job
-        And the Workflow reports fatal errors at the Teardown state
-        Then the Workflow has eventually been deleted
-        And the job has eventually been COMPLETED

--- a/testsuite/integration/src/pytest.ini
+++ b/testsuite/integration/src/pytest.ini
@@ -25,4 +25,3 @@ markers =
   happy_one
   fatal_one
   fatal_two
-  fatal_three


### PR DESCRIPTION
The feature code appears to be ok.  The test has a race; work it as a separate effort.