### PR TITLE
Teardown return string as second return value

### DIFF
--- a/src/burst_buffer/burst_buffer.lua
+++ b/src/burst_buffer/burst_buffer.lua
@@ -688,7 +688,7 @@ function slurm_bb_job_teardown(job_id, job_script, hurry)
 	end
 
 	if ret == slurm.SUCCESS then
-		err = nil
+		err = ""
 	end
 	return ret, err
 end


### PR DESCRIPTION
While teardown technically still works, I get an error in the slurm log when returning nil as the second return value in the teardown script. This PR returns an empty string instead.

```
[2023-09-26T19:11:37.457] slurmscriptd: error: _handle_lua_return: Cannot handle non-string as second return value for lua function slurm_bb_job_teardown.
```

Kevin Pelzel <kpelzel@lanl.gov>