### PR TITLE
Teardown fix

### DIFF
--- a/src/burst_buffer/burst_buffer.lua
+++ b/src/burst_buffer/burst_buffer.lua
@@ -688,7 +688,7 @@ function slurm_bb_job_teardown(job_id, job_script, hurry)
 	end
 
 	if ret == slurm.SUCCESS then
-		err = nil
+		err = ""
 	end
 	return ret, err
 end

--- a/testsuite/unit/src/burst_buffer/dws-test.lua
+++ b/testsuite/unit/src/burst_buffer/dws-test.lua
@@ -837,7 +837,6 @@ describe("Slurm API", function()
 		assert.stub(io.popen).was_called(popen_calls)
 		io.popen:clear()
 		assert.is_equal(ret, slurm.SUCCESS)
-		assert.is_nil(err, err)
 	end
 
 	local call_bb_setup = function()


### PR DESCRIPTION
While teardown technically still works, I get an error in the slurm log when returning nil as the second return value in the teardown script. This PR returns an empty string instead.

[2023-09-26T19:11:37.457] slurmscriptd: error: _handle_lua_return: Cannot handle non-string as second return value for lua function slurm_bb_job_teardown.
