### PR TITLE
Move to cert-manager 1.13.1

### DIFF
--- a/testsuite/integration/kind/kind.sh
+++ b/testsuite/integration/kind/kind.sh
@@ -52,7 +52,7 @@ install_dependencies () {
 
   # Pull cert-manager into the local cache and push into KIND.  Sometimes
   # the KIND env cannot pull it from upstream.
-  CERTVER=v1.11.1
+  CERTVER=v1.13.1
   for part in controller webhook cainjector
   do
       image=quay.io/jetstack/cert-manager-$part:$CERTVER


### PR DESCRIPTION
Cert-manager 1.12.0 and 1.13.0 were big releases.  It's time to catch up.