### PR TITLE
Check for nil home directory

### DIFF
--- a/src/burst_buffer/burst_buffer.lua
+++ b/src/burst_buffer/burst_buffer.lua
@@ -406,6 +406,9 @@ end
 function DWS:kubectl_cache_home()
 
 	local dir_exists = function(dname)
+		if dname == nil or dname == '' then
+			return false
+		end
 		local cmd = "test -d " .. dname
 		local done, _ = self:io_popen(cmd)
 		return done


### PR DESCRIPTION
If the slurm users home directory is nil then the dir_exists function will fail. We encountered this while running slurmctl as root. 

log output:
`error: /etc/slurm/burst_buffer.lua: /etc/slurm/burst_buffer.lua:407: attempt to concatenate a nil value (local 'dname')`