### PR TITLE
Support multi architecture building

### DIFF
--- a/testsuite/integration/Dockerfile
+++ b/testsuite/integration/Dockerfile
@@ -2,6 +2,9 @@ FROM rockylinux:9 AS testbase
 
 COPY requirements.txt /requirements.txt
 
+ARG TARGETARCH
+ARG TARGETOS
+
 RUN sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/rocky* && \
     sed -i 's|^#baseurl=|baseurl=|' /etc/yum.repos.d/rocky*
 
@@ -13,7 +16,7 @@ RUN yum update -y && \
     dnf check-update && \
     dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo && \
     dnf install -y docker-ce-cli && \
-    curl -k -LO "https://dl.k8s.io/release/$(curl -k -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
+    curl -k -LO "https://dl.k8s.io/release/$(curl -k -L -s https://dl.k8s.io/release/stable.txt)/bin/${TARGETOS}/${TARGETARCH}/kubectl" && \
     install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
     pip install -r requirements.txt
 


### PR DESCRIPTION
I'm running through the example at https://github.com/DataWorkflowServices/dws-slurm-bb-plugin?tab=readme-ov-file#the-integration-test-environment-as-a-playground with the latest versions of everything and am making PRs based on changes I found I need for proper building on arm.

Using TARGETARCH in the dockerfile should retain functionality for amd64 and allow for building on other archs. It also opens up the possibility for multi arch images.
